### PR TITLE
log -> logrus

### DIFF
--- a/internal/provider/testutils/local_server.go
+++ b/internal/provider/testutils/local_server.go
@@ -2,7 +2,7 @@ package testutils
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
 


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)